### PR TITLE
Use json array in CMD

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
 FROM gliderlabs/alpine
 RUN apk-install nginx && mkdir /tmp/nginx && mkdir -p /run/nginx
-ADD ./nginx-redirect.conf /etc/nginx/nginx.conf
+ADD ./nginx.conf /etc/nginx/nginx.conf
 CMD ["nginx"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
 FROM gliderlabs/alpine
 RUN apk-install nginx && mkdir /tmp/nginx && mkdir -p /run/nginx
-ADD ./nginx.conf /etc/nginx/nginx.conf
-CMD nginx
+ADD ./nginx-redirect.conf /etc/nginx/nginx.conf
+CMD ["nginx"]


### PR DESCRIPTION
When not using json array in CMD, it is not possible to stop the container normally